### PR TITLE
Fix spacing around codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Group Alias is a simple [Hubot][hubot] plugin which allows you to define new *"@
 
 ## Configuration
 1. All this package to your `package.json`. Do this by running this command:
+
 	```sh
 	npm i --save hubot-group-alias
 	```
 2. Add "hubot-group-alias" to `external-scripts.json`:
+
 	```json
 	[
 	"...",


### PR DESCRIPTION
The lack of spacing around the codeblocks was causing `sh` and `json` to be added to the commands, rather than being used to format the codeblock.
